### PR TITLE
Adding requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 ###Summary
 Maui automatically identifies main topics in text documents. Depending on the task, topics are tags, keywords, keyphrases, vocabulary terms, descriptors, index terms or titles of Wikipedia articles.
 
+###Requirements
+* Java 1.7 (Currently, it does not run on Java 1.8)
+
 ###Demo
 You can try out this live [Maui demo](http://maui-indexer.appspot.com/) by just copying and pasting a piece of text of your choice or uploading a document in Word or PDF format.
 


### PR DESCRIPTION
I confirmed that maven fails when using Java 1.8.
Adding requirements section for making it explicit about this issue.
